### PR TITLE
fix empty responses

### DIFF
--- a/lib/rack/forward.rb
+++ b/lib/rack/forward.rb
@@ -70,7 +70,7 @@ module Rack
 
       headers['Set-Cookie'] = cookies.join('\n')
 
-      [sub_response.code.to_i, headers, [sub_response.read_body]]
+      [sub_response.code.to_i, headers, [sub_response.read_body.to_s]]
     end
 
     private


### PR DESCRIPTION
I came across an issue when forwarding `HEAD` requests to another service: the response body would be empty, or in this specific case, `nil`. When the `Rack::ETag` middleware [processes](https://github.com/rack/rack/blob/e2a8388d59bbad0cb867150185770ad76e80d31a/lib/rack/etag.rb#L68) the response, it attempts to call `.empty?` on it. Calling `.empty?` on `nil` barfs. This PR makes sure that `rack-forward` treats an empty body response as an empty string.