### PR TITLE
fix empty content-type

### DIFF
--- a/lib/rack/forward.rb
+++ b/lib/rack/forward.rb
@@ -27,7 +27,10 @@ module Rack
       if sub_request.request_body_permitted? and req.body
         sub_request.body_stream = req.body
         sub_request.content_length = req.content_length
-        sub_request.content_type = req.content_type
+
+        if req.content_type
+          sub_request.content_type = req.content_type
+        end
       end
 
       sub_request['X-Identity-Service-Key'] = req.env['HTTP_X_IDENTITY_SERVICE_KEY']


### PR DESCRIPTION
I came across an issue where if the `Content-Type` header doesn't exist on the incoming request, trying to set it on the sub-request will fail. (This happens in [`net/http/header'](https://github.com/ruby/ruby/blob/v2_2_4/lib/net/http/header.rb#L349) where `type` is `nil`). This PR conditionally sets `content_type` if it's not nil.